### PR TITLE
Refactored port configuration from start listening.

### DIFF
--- a/ublox.Core/Device.cs
+++ b/ublox.Core/Device.cs
@@ -49,10 +49,15 @@ namespace ublox.Core
             _listenCancellationTokenSource.Cancel();
         }
 
+        [Obsolete("Obsolete : call StartListeningAsync and ConfigurePortAsync with appropriate parameters if needed")]
         public async Task InitializeAsync()
         {
+            throw new NotImplementedException();
+        }
+
+        public async Task StartListeningAsync()
+        {
             await Task.Run(() => ListenAsync());
-            await ConfigurePortAsync(UartPort.Uart1, 9600, PortInProtocols.Ubx, PortOutProtocols.Ubx);
         }
 
         public Task ConfigurePortAsync(UartPort port, uint baudRate, PortInProtocols inProtocols, PortOutProtocols outProtocols, CancellationToken cancellationToken = default(CancellationToken))

--- a/ublox.Core/Device.cs
+++ b/ublox.Core/Device.cs
@@ -49,10 +49,11 @@ namespace ublox.Core
             _listenCancellationTokenSource.Cancel();
         }
 
-        [Obsolete("Obsolete : call StartListeningAsync and ConfigurePortAsync with appropriate parameters if needed")]
+        [Obsolete("Use StartListeningAsync and ConfigurePortAsync as needed")]
         public async Task InitializeAsync()
         {
-            throw new NotImplementedException();
+            await StartListeningAsync();
+            await ConfigurePortAsync(UartPort.Uart1, 9600, PortInProtocols.Ubx, PortOutProtocols.Ubx);
         }
 
         public async Task StartListeningAsync()


### PR DESCRIPTION
InitializeAsync divided into StartListeningAsync and ConfigurePortAsync to allow custom port configuration or avoid it entirely.

We are running the internal uart1 with a different config, and for now we program it with u-center.

![image](https://user-images.githubusercontent.com/1522516/34099103-d677aa6a-e3de-11e7-9125-9b59aa607ee1.png)

