### PR TITLE
fix Nanosecond accuracy

### DIFF
--- a/ublox.Core/Constants.cs
+++ b/ublox.Core/Constants.cs
@@ -3,7 +3,7 @@
     public static class Constants
     {
         public const ushort SyncCharacters = 0x62b5;
-        public const int TicksPerNanosecond = 100;
+        public const int NanosecondsPerTick = 100;
         public const double MillimetersPerMeter = 1000;
     }
 }

--- a/ublox.Core/Data/SignedNanosecond2.cs
+++ b/ublox.Core/Data/SignedNanosecond2.cs
@@ -10,8 +10,8 @@ namespace ublox.Core.Data
         [Ignore]
         public TimeSpan Time
         {
-            get => TimeSpan.FromTicks(Value * Constants.TicksPerNanosecond);
-            set => Value = (short)(value.Ticks / (double)Constants.TicksPerNanosecond);
+            get => TimeSpan.FromTicks(Value / Constants.NanosecondsPerTick);
+            set => Value = (short)(value.Ticks * (double)Constants.NanosecondsPerTick);
         }
     }
 }

--- a/ublox.Core/Data/SignedNanosecond4.cs
+++ b/ublox.Core/Data/SignedNanosecond4.cs
@@ -10,8 +10,8 @@ namespace ublox.Core.Data
         [Ignore]
         public TimeSpan Time
         {
-            get => TimeSpan.FromTicks(Value * Constants.TicksPerNanosecond);
-            set => Value = (int)(value.Ticks / (double)Constants.TicksPerNanosecond);
+            get => TimeSpan.FromTicks(Value / Constants.NanosecondsPerTick);
+            set => Value = (int)(value.Ticks * (double)Constants.NanosecondsPerTick);
         }
     }
 }

--- a/ublox.Core/Data/SignedVelocity.cs
+++ b/ublox.Core/Data/SignedVelocity.cs
@@ -12,7 +12,7 @@ namespace ublox.Core.Data
         {
         }
 
-        public uint MillimetersPerSecond { get; set; }
+        public int MillimetersPerSecond { get; set; }
 
         protected override double GetMillimetersPerSecond()
         {
@@ -21,7 +21,7 @@ namespace ublox.Core.Data
 
         protected override void SetMillimetersPerSecond(double millimetersPerSecond)
         {
-            MillimetersPerSecond = Convert.ToUInt32(millimetersPerSecond);
+            MillimetersPerSecond = Convert.ToInt32(millimetersPerSecond);
         }
     }
 }

--- a/ublox.Core/Data/UbloxDateTime.cs
+++ b/ublox.Core/Data/UbloxDateTime.cs
@@ -14,6 +14,21 @@ namespace ublox.Core.Data
             DateTime = dateTime;
         }
 
+        public UbloxDateTime(ushort year, byte month, byte day, byte hour, byte minute, byte second, byte validityFlags, uint timeAccuractyNs, int nanosecond)
+        {
+            Year = year;
+            Month = month;
+            Day = day;
+            Hour = hour;
+            Minute = minute;
+            Second = second;
+
+            ValidityFlags = validityFlags;
+            TimeAccuracyNs = timeAccuractyNs;
+
+            Nanosecond = nanosecond;
+        }
+
         [FieldOrder(0)]
         public ushort Year { get; set; }
 
@@ -47,7 +62,7 @@ namespace ublox.Core.Data
             get
             {
                 var dt = new DateTime(Year, Month, Day, Hour, Minute, Second);
-                var ticks = Nanosecond * Constants.TicksPerNanosecond;
+                var ticks = Nanosecond / Constants.NanosecondsPerTick;
                 return dt.AddTicks(ticks);
             }
 
@@ -67,11 +82,11 @@ namespace ublox.Core.Data
                 }
 
                 var remainder = value - new DateTime(Year, Month, Day, Hour, Minute, Second);
-                Nanosecond = (int) (remainder.Ticks / Constants.TicksPerNanosecond);
+                Nanosecond = (int) (remainder.Ticks * Constants.NanosecondsPerTick);
             }
         }
 
         [Ignore]
-        public TimeSpan TimeAccuracy => TimeSpan.FromTicks(TimeAccuracyNs * Constants.TicksPerNanosecond);
+        public TimeSpan TimeAccuracy => TimeSpan.FromTicks(TimeAccuracyNs / Constants.NanosecondsPerTick);
     }
 }

--- a/ublox.Core/Data/UbloxDateTimeNoAccuracy.cs
+++ b/ublox.Core/Data/UbloxDateTimeNoAccuracy.cs
@@ -44,7 +44,7 @@ namespace ublox.Core.Data
             get
             {
                 var dt = new DateTime(Year, Month, Day, Hour, Minute, Second);
-                var ticks = Nanosecond * Constants.TicksPerNanosecond;
+                var ticks = Nanosecond / Constants.NanosecondsPerTick;
                 return dt.AddTicks(ticks);
             }
 
@@ -64,7 +64,7 @@ namespace ublox.Core.Data
                 }
 
                 var remainder = value - new DateTime(Year, Month, Day, Hour, Minute, Second);
-                Nanosecond = (int) (remainder.Ticks / Constants.TicksPerNanosecond);
+                Nanosecond = (int) (remainder.Ticks * Constants.NanosecondsPerTick);
             }
         }
     }


### PR DESCRIPTION
from MSDN : 

> A single tick represents one hundred nanoseconds or one ten-millionth of a second. There are 10,000 ticks in a millisecond, or 10 million ticks in a second.
